### PR TITLE
Remove preact signals

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -38,17 +38,18 @@ downButton.addEventListener("click", () => {
   logContainer.children[logContainer.children.length - 1].scrollIntoView();
 });
 let showButton = downButton.classList.contains("show");
+const GOAL_DIST = 150;
 logContainer.addEventListener("scroll", (e) => {
-  const dist =
+  const dist = Math.abs(
     logContainer.scrollHeight -
-    logContainer.scrollTop -
-    logContainer.clientHeight;
-  console.log({ dist });
-  const GOAL_DIST = 150;
-  if (Math.abs(dist) > GOAL_DIST && !showButton) {
+      logContainer.scrollTop -
+      logContainer.clientHeight
+  );
+  
+  if (dist > GOAL_DIST && !showButton) {
     downButton.classList.add("show");
     showButton = true;
-  } else if (Math.abs(dist) < GOAL_DIST && showButton) {
+  } else if (dist < GOAL_DIST && showButton) {
     downButton.classList.remove("show");
     showButton = false;
   }

--- a/public/index.js
+++ b/public/index.js
@@ -15,8 +15,9 @@ const setFilter = (newText) => {
   {
     // update filtered items
     let filterCount = 0;
+    const filter = filterText.toLowerCase();
     for (const logEl of $$(".container .log")) {
-      const shouldDisplay = logEl.textContent.includes(filterText);
+      const shouldDisplay = logEl.textContent.toLowerCase().includes(filter);
       if (shouldDisplay) filterCount++;
       logEl.style.display = shouldDisplay ? "" : "none";
     }

--- a/public/index.js
+++ b/public/index.js
@@ -69,33 +69,34 @@ tagsContainer.addEventListener("click", (e) => {
     }
     tagEl.setAttribute("variant", "primary");
     tagEl.setAttribute("aria-pressed", "true");
-    const text = `[${tagEl.textContent}]`;
-    filterInput.value = text;
-    setFilter(text);
+    filterInput.value = tagEl.textContent;
+    setFilter(tagEl.textContent);
   } else {
     tagEl.setAttribute("variant", "neutral");
     tagEl.setAttribute("aria-pressed", "true");
     filterInput.value = "";
-    setFilter('');
+    setFilter("");
   }
 });
 /** @type {Set<string>} */
 const tagsSet = new Set();
-/** @param {string} text */
-function maybeAddTag(text) {
-  const tagText = text.match(/\[(\w+)\]/)?.[1];
-  if (!tagText) return;
-  if (tagsSet.has(tagText)) return;
+/** @param {HTMLElement} logEl */
+function maybeAddTag(logEl) {
+  const newTags = [...logEl.querySelectorAll(".tag")]
+    .map((el) => el.textContent)
+    .filter((tag) => !tagsSet.has(tag));
 
-  tagsSet.add(tagText);
-  const tag = cloneTemplate(".badge", { textContent: tagText });
-  tagsContainer.append(tag);
+  for (const tagText of newTags) {
+    tagsSet.add(tagText);
+    const tag = cloneTemplate(".badge", { textContent: tagText });
+    tagsContainer.append(tag);
+  }
 }
 
 /** @param {CliInput} cliInput */
 function getLogEl({ input, date }) {
   const logEl = cloneTemplate(".log", { innerHTML: highlightText(input) });
-  maybeAddTag(input);
+  maybeAddTag(logEl);
   logEl.setAttribute(
     "data-date",
     new Date(date).toLocaleDateString("en-US", {

--- a/public/lib.js
+++ b/public/lib.js
@@ -1,9 +1,3 @@
-import {
-  signal as signalPreact,
-  effect as effectPreact,
-  computed as computedPreact,
-} from "https://esm.sh/@preact/signals";
-
 /**
  * Document query selector alias
  * @type {(selector: string) => HTMLElement}
@@ -16,24 +10,6 @@ export const $ = (s) => document.querySelector(s);
  */
 export const $$ = (s) =>
   /**@type {HTMLElement[]}*/ ([...document.querySelectorAll(s)]);
-
-/**
- * Preact signal alias
- * @type {<T>(init: T) => { value: T }}
- */
-export const signal = signalPreact;
-
-/**
- * Preact effect alias
- * @type {(func: () => void) => void}
- */
-export const effect = effectPreact;
-
-/**
- * Preact computed alias
- * @type {<T>(func: () => T) => T}
- */
-export const computed = computedPreact;
 
 const cloneMap = new Map();
 /**


### PR DESCRIPTION
We can probably re-add a slimmer signals library that we inline.

The signals were temporarily making things more confusing. There's a possibility we'll move back to preact at some point, but it's doing more harm than good right now. 

I also fixed some other unrelated issues while I was there.