### PR TITLE
Add query language

### DIFF
--- a/public/contextmenu.js
+++ b/public/contextmenu.js
@@ -64,7 +64,7 @@ contextMenu.addEventListener(
     } else if (action === "copy-id") {
       copyText(selectedLog.dataset.id, "log ID");
     } else {
-      setFilter('');
+      setFilter('', true);
       selectedLog.scrollIntoView();
     }
 

--- a/public/filter.js
+++ b/public/filter.js
@@ -26,9 +26,10 @@ export const setFilter = (newText) => {
   let filterCount = logs.length;
   let filter = filterText.toLowerCase();
 
+  const SELECTOR_MATCH = /@@([\w,]+)/g;
 
-  if (/@@[\w,]+/.test(filter)) {
-    const tags = [...filter.matchAll(/@@([\w,]+)/g)].map((m) => m[1]);
+  if (SELECTOR_MATCH.test(filter)) {
+    const tags = [...filter.matchAll(SELECTOR_MATCH)].map((m) => m[1]);
     logs = logs.filter((logEl) => {
       console.log(tags)
       const shouldDisplay = tags
@@ -50,7 +51,7 @@ export const setFilter = (newText) => {
       logEl.style.display = shouldDisplay ? "" : "none";
       return shouldDisplay;
     });
-    filter = filter.replace(/@@[\w,]+/g, "").trim();
+    filter = filter.replace(SELECTOR_MATCH, "").trim();
   }
 
   if (filter) {

--- a/public/filter.js
+++ b/public/filter.js
@@ -22,30 +22,41 @@ export const applyFilter = (input, logEl) => {
 export const setFilter = (newText) => {
   filterText = newText;
 
-  let filterCount = 0;
-  const filter = filterText.toLowerCase();
-  if (/@`.+?`/.test(filter)) {
-    const tags = [...filter.matchAll(/@`(.+?)`/g)].map((m) => m[1]);
-    for (const logEl of $$(".container .log")) {
+  let logs = $$(".container .log");
+  let filterCount = logs.length;
+  let filter = filterText.toLowerCase();
+
+
+  if (/@@[\w,]+/.test(filter)) {
+    const tags = [...filter.matchAll(/@@([\w,]+)/g)].map((m) => m[1]);
+    logs = logs.filter((logEl) => {
+      console.log(tags)
       const shouldDisplay = tags
         .map((tagGroup) => {
           const elements = logEl.querySelectorAll(
             tagGroup
               .split(/\s*,\s*/)
+              // remove empty strings from trailing commas
+              .filter((s) => s.length)
               .map((tag) => `span.${tag}`)
               .join(",")
           );
+          console.log(elements)
           return elements.length;
         })
         .every((len) => len > 0);
 
-      if (shouldDisplay) filterCount++;
+      if (!shouldDisplay) filterCount--;
       logEl.style.display = shouldDisplay ? "" : "none";
-    }
-  } else {
-    for (const logEl of $$(".container .log")) {
+      return shouldDisplay;
+    });
+    filter = filter.replace(/@@[\w,]+/g, "").trim();
+  }
+
+  if (filter) {
+    for (const logEl of logs) {
       const shouldDisplay = logEl.textContent.toLowerCase().includes(filter);
-      if (shouldDisplay) filterCount++;
+      if (!shouldDisplay) filterCount--;
       logEl.style.display = shouldDisplay ? "" : "none";
     }
   }

--- a/public/filter.js
+++ b/public/filter.js
@@ -22,17 +22,14 @@ export const applyFilter = (input, logEl) => {
 export const setFilter = (newText) => {
   filterText = newText;
 
-  {
-    // update filtered items
-    let filterCount = 0;
-    const filter = filterText.toLowerCase();
-    for (const logEl of $$(".container .log")) {
-      const shouldDisplay = logEl.textContent.toLowerCase().includes(filter);
-      if (shouldDisplay) filterCount++;
-      logEl.style.display = shouldDisplay ? "" : "none";
-    }
-    filterItemsCount = filterCount;
+  let filterCount = 0;
+  const filter = filterText.toLowerCase();
+  for (const logEl of $$(".container .log")) {
+    const shouldDisplay = logEl.textContent.toLowerCase().includes(filter);
+    if (shouldDisplay) filterCount++;
+    logEl.style.display = shouldDisplay ? "" : "none";
   }
+  filterItemsCount = filterCount;
 
   // set filter log count text
   $(".log-count .filtered").textContent = filterText.length

--- a/public/filter.js
+++ b/public/filter.js
@@ -62,7 +62,6 @@ const matchTags = (tagGroups, logEl) => {
         if (!textValue) continue;
         elements = elements.filter((el) => {
           if (!el.classList.contains(tag)) return true;
-          console.log(el.textContent, textValue)
           return el.textContent === textValue;
         });
       }
@@ -73,23 +72,28 @@ const matchTags = (tagGroups, logEl) => {
 };
 
 /**
- * Applies filter to element based off of input content
- *
- * @param {string} input
- * @param {HTMLElement} logEl */
-export const applyFilter = (input, logEl) => {
+ * Checks if log matches filter (based on global variable filterText)
+ * @param {HTMLElement} logEl DOM element for log
+ */
+const elMatchesFilter = (logEl) => {
   let filter = filterText;
+
   const tags = extractTagGroups(filterText);
   if (tags.length) {
-    if (!matchTags(tags, logEl)) {
-      logEl.style.display = "none";
-      return;
-    }
-
+    if (!matchTags(tags, logEl)) return false;
+    
     filter = filter.replace(getSelector(), "").trim();
+    if (!filter) return true;
   }
 
-  const shouldDisplay = input.includes(filterText);
+  return logEl.textContent.toLowerCase().includes(filterText.toLowerCase());
+};
+
+/**
+ * Applies filter to element based off of input content
+ * @param {HTMLElement} logEl */
+export const applyFilter = (logEl) => {
+  const shouldDisplay = elMatchesFilter(logEl);
   logEl.style.display = shouldDisplay ? "" : "none";
   if (shouldDisplay) filterItemsCount++;
 };
@@ -113,26 +117,11 @@ export const setFilter = (newText, changeInput = false) => {
     return;
   }
 
-  if (getSelector().test(filter)) {
-    const tagGroups = extractTagGroups(filter);
+  for (const logEl of logs) {
+    const shouldDisplay = elMatchesFilter(logEl);
 
-    logs = logs.filter((logEl) => {
-      const shouldDisplay = matchTags(tagGroups, logEl);
-
-      if (!shouldDisplay) filterCount--;
-      logEl.style.display = shouldDisplay ? "" : "none";
-      return shouldDisplay;
-    });
-    filter = filter.replace(getSelector(), "").trim();
-  }
-
-  if (filter) {
-    filter = filter.toLowerCase();
-    for (const logEl of logs) {
-      const shouldDisplay = logEl.textContent.toLowerCase().includes(filter);
-      if (!shouldDisplay) filterCount--;
-      logEl.style.display = shouldDisplay ? "" : "none";
-    }
+    if (!shouldDisplay) filterCount--;
+    logEl.style.display = shouldDisplay ? "" : "none";
   }
 
   filterItemsCount = filterCount;

--- a/public/filter.js
+++ b/public/filter.js
@@ -7,16 +7,16 @@ const filterInputEl = /** @type {HTMLInputElement} */ ($("sl-input.filter"));
 let filterText = "";
 let filterItemsCount = 0;
 
-/** 
+/**
  * Applies filter to element based off of input content
- * 
+ *
  * @param {string} input
  * @param {HTMLElement} logEl */
 export const applyFilter = (input, logEl) => {
   const shouldDisplay = input.includes(filterText);
   logEl.style.display = shouldDisplay ? "" : "none";
   if (shouldDisplay) filterItemsCount++;
-}
+};
 
 /** @param {string} newText */
 export const setFilter = (newText) => {
@@ -24,11 +24,32 @@ export const setFilter = (newText) => {
 
   let filterCount = 0;
   const filter = filterText.toLowerCase();
-  for (const logEl of $$(".container .log")) {
-    const shouldDisplay = logEl.textContent.toLowerCase().includes(filter);
-    if (shouldDisplay) filterCount++;
-    logEl.style.display = shouldDisplay ? "" : "none";
+  if (/@`.+?`/.test(filter)) {
+    const tags = [...filter.matchAll(/@`(.+?)`/g)].map((m) => m[1]);
+    for (const logEl of $$(".container .log")) {
+      const shouldDisplay = tags
+        .map((tagGroup) => {
+          const elements = logEl.querySelectorAll(
+            tagGroup
+              .split(/\s*,\s*/)
+              .map((tag) => `span.${tag}`)
+              .join(",")
+          );
+          return elements.length;
+        })
+        .every((len) => len > 0);
+
+      if (shouldDisplay) filterCount++;
+      logEl.style.display = shouldDisplay ? "" : "none";
+    }
+  } else {
+    for (const logEl of $$(".container .log")) {
+      const shouldDisplay = logEl.textContent.toLowerCase().includes(filter);
+      if (shouldDisplay) filterCount++;
+      logEl.style.display = shouldDisplay ? "" : "none";
+    }
   }
+
   filterItemsCount = filterCount;
 
   // set filter log count text
@@ -45,8 +66,9 @@ filterInputEl.addEventListener("input", () => {
   setFilter(filter);
 });
 
-document.addEventListener('keydown', e => {
-  if (e.key !== '/' || e.metaKey || document.activeElement === filterInputEl) return;
+document.addEventListener("keydown", (e) => {
+  if (e.key !== "/" || e.metaKey || document.activeElement === filterInputEl)
+    return;
 
   filterInputEl.focus();
   e.preventDefault();

--- a/public/index.js
+++ b/public/index.js
@@ -1,6 +1,7 @@
 import { highlightText } from "./highlight.js";
-import { $, $$, cloneTemplate, isInView } from "./lib.js";
-import { applyFilter, setFilter } from "./filter.js";
+import { $, cloneTemplate, isInView } from "./lib.js";
+import { applyFilter } from "./filter.js";
+import { maybeAddTag } from "./tags.js";
 import './contextmenu.js';
 import './command-palette.js';
 
@@ -33,45 +34,6 @@ logContainer.addEventListener("scroll", (e) => {
     showButton = false;
   }
 });
-
-const tagsContainer = $(".tags");
-tagsContainer.addEventListener("click", (e) => {
-  const tagEl = e.target;
-  if (!(tagEl instanceof HTMLElement)) return;
-  if (tagEl.tagName !== "SL-BADGE") return;
-
-  const filterInput = /** @type {HTMLInputElement} */ ($(".filter"));
-  if (tagEl.getAttribute("variant") === "neutral") {
-    for (const tag of $$(".tags sl-badge")) {
-      tag.setAttribute("variant", "neutral");
-      tag.setAttribute("aria-pressed", "false");
-    }
-    tagEl.setAttribute("variant", "primary");
-    tagEl.setAttribute("aria-pressed", "true");
-    filterInput.value = tagEl.textContent;
-    setFilter(tagEl.textContent);
-  } else {
-    tagEl.setAttribute("variant", "neutral");
-    tagEl.setAttribute("aria-pressed", "true");
-    filterInput.value = "";
-    setFilter("");
-  }
-});
-
-/** @type {Set<string>} */
-const tagsSet = new Set();
-/** @param {HTMLElement} logEl */
-function maybeAddTag(logEl) {
-  const newTags = [...logEl.querySelectorAll(".tag")]
-    .map((el) => el.textContent)
-    .filter((tag) => !tagsSet.has(tag));
-
-  for (const tagText of newTags) {
-    tagsSet.add(tagText);
-    const tag = cloneTemplate(".badge", { textContent: tagText });
-    tagsContainer.append(tag);
-  }
-}
 
 /** @param {CliInput} cliInput */
 function getLogEl({ input, date, id }) {

--- a/public/index.js
+++ b/public/index.js
@@ -51,7 +51,7 @@ function getLogEl({ input, date, id }) {
     })
   );
 
-  applyFilter(input, logEl);
+  applyFilter(logEl);
 
   return logEl;
 }

--- a/public/tags.js
+++ b/public/tags.js
@@ -8,7 +8,6 @@ tagsContainer.addEventListener("click", (e) => {
   if (!(tagEl instanceof HTMLElement)) return;
   if (tagEl.tagName !== "SL-BADGE") return;
 
-  const filterInput = /** @type {HTMLInputElement} */ ($(".filter"));
   if (tagEl.getAttribute("variant") === "neutral") {
     for (const tag of $$(".tags sl-badge")) {
       tag.setAttribute("variant", "neutral");
@@ -16,25 +15,22 @@ tagsContainer.addEventListener("click", (e) => {
     }
     tagEl.setAttribute("variant", "primary");
     tagEl.setAttribute("aria-pressed", "true");
-    filterInput.value = `@@tag="${tagEl.textContent}"`;
-    setFilter(tagEl.textContent);
+    setFilter(`@@tag="${tagEl.textContent}"`, true);
   } else {
     tagEl.setAttribute("variant", "neutral");
     tagEl.setAttribute("aria-pressed", "true");
-    filterInput.value = "";
-    setFilter("");
+    setFilter("", true);
   }
 });
-
 
 /** @type {Set<string>} */
 const tagsSet = new Set();
 
-/** 
+/**
  * Finds all tag elements in a log.
  * Only adds a new tag if it is not already present.
- * 
- * @param {HTMLElement} logEl 
+ *
+ * @param {HTMLElement} logEl
  */
 export function maybeAddTag(logEl) {
   const newTags = [...logEl.querySelectorAll(".tag")]

--- a/public/tags.js
+++ b/public/tags.js
@@ -1,0 +1,49 @@
+import { setFilter } from "./filter.js";
+import { $, $$, cloneTemplate } from "./lib.js";
+
+const tagsContainer = $(".tags");
+
+tagsContainer.addEventListener("click", (e) => {
+  const tagEl = e.target;
+  if (!(tagEl instanceof HTMLElement)) return;
+  if (tagEl.tagName !== "SL-BADGE") return;
+
+  const filterInput = /** @type {HTMLInputElement} */ ($(".filter"));
+  if (tagEl.getAttribute("variant") === "neutral") {
+    for (const tag of $$(".tags sl-badge")) {
+      tag.setAttribute("variant", "neutral");
+      tag.setAttribute("aria-pressed", "false");
+    }
+    tagEl.setAttribute("variant", "primary");
+    tagEl.setAttribute("aria-pressed", "true");
+    filterInput.value = `@@tag="${tagEl.textContent}"`;
+    setFilter(tagEl.textContent);
+  } else {
+    tagEl.setAttribute("variant", "neutral");
+    tagEl.setAttribute("aria-pressed", "true");
+    filterInput.value = "";
+    setFilter("");
+  }
+});
+
+
+/** @type {Set<string>} */
+const tagsSet = new Set();
+
+/** 
+ * Finds all tag elements in a log.
+ * Only adds a new tag if it is not already present.
+ * 
+ * @param {HTMLElement} logEl 
+ */
+export function maybeAddTag(logEl) {
+  const newTags = [...logEl.querySelectorAll(".tag")]
+    .map((el) => el.textContent)
+    .filter((tag) => !tagsSet.has(tag));
+
+  for (const tagText of newTags) {
+    tagsSet.add(tagText);
+    const tag = cloneTemplate(".badge", { textContent: tagText });
+    tagsContainer.append(tag);
+  }
+}


### PR DESCRIPTION
closes https://github.com/EmNudge/logpipe/issues/26

Syntax:
```
selector: <classname>[="<content>"]
@@<selector>[,<selector>]+
```

examples:
> match logs containing `span.tag` with the string "Info" or `span.number` containing anything
```
@@tag="Info",number
```
> match logs containing all of `span.tag`, `span.number` with the string "42", and `span.string`
```
@@tag @@number=42 @@string
```


There's still some improvements to be made, but it works!!