### PR TITLE
Allow saving logs

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -95,7 +95,7 @@ const PUBLIC_DIR = join(fileURLToPath(import.meta.url), "..", "public");
 
 const server = http
   .createServer(async (req, res) => {
-    if (req.url === "/cli-input") {
+    if (req.url === "/_/cli-input") {
       res.writeHead(200, {
         "Content-Type": "text/event-stream",
         Connection: "keep-alive",

--- a/public/command-palette.js
+++ b/public/command-palette.js
@@ -55,6 +55,22 @@ helpFormEl.addEventListener("submit", (e) => {
   commandPaletteEl.hide();
 });
 
+/** @type {HTMLFormElement} */
+const saveFormEl = commandPaletteEl.querySelector("form.save-to-disk");
+saveFormEl.addEventListener("submit", (e) => {
+  e.preventDefault();
+
+  const { folder, file } = Object.fromEntries([...new FormData(saveFormEl)]);
+  if (!folder || !file) {
+    console.error('no file or folder');
+    return;
+  }
+
+  
+
+  commandPaletteEl.hide();
+});
+
 document.body.addEventListener("keydown", (e) => {
   if (e.key === "k" && e.metaKey) {
     commandPaletteEl.show();
@@ -88,11 +104,13 @@ inputEl.addEventListener("keydown", (e) => {
 listEl.addEventListener(
   "sl-select",
   (/** @type {Event & { detail: any }} e */ e) => {
-    /** @type {'set-title' | 'help'} */
+    /** @type {'set-title' | 'save' | 'help'} */
     const action = e.detail.item.value;
 
     if (action === "set-title") {
       showForm(setTitleFormEl, "Set Title");
+    } else if (action === "save") {
+      showForm(saveFormEl, "Save To Disk");
     } else if (action === "help") {
       showForm(helpFormEl, "Help Menu");
     }

--- a/public/command-palette.js
+++ b/public/command-palette.js
@@ -96,7 +96,7 @@ listEl.addEventListener(
     if (action === "set-title") {
       showForm(setTitleFormEl, "Set Title");
     } else if (action === "save") {
-      downloadResource("/_/logs");
+      downloadResource("/_/logs", "logs");
       commandPaletteEl.hide();
     } else if (action === "help") {
       showForm(helpFormEl, "Help Menu");

--- a/public/command-palette.js
+++ b/public/command-palette.js
@@ -1,3 +1,5 @@
+import { downloadResource } from "./lib.js";
+
 /** @type {Element & { [key: string]: () => Promise<void> }} */
 const commandPaletteEl = document.querySelector("sl-dialog.command-palette");
 
@@ -55,22 +57,6 @@ helpFormEl.addEventListener("submit", (e) => {
   commandPaletteEl.hide();
 });
 
-/** @type {HTMLFormElement} */
-const saveFormEl = commandPaletteEl.querySelector("form.save-to-disk");
-saveFormEl.addEventListener("submit", (e) => {
-  e.preventDefault();
-
-  const { folder, file } = Object.fromEntries([...new FormData(saveFormEl)]);
-  if (!folder || !file) {
-    console.error('no file or folder');
-    return;
-  }
-
-  
-
-  commandPaletteEl.hide();
-});
-
 document.body.addEventListener("keydown", (e) => {
   if (e.key === "k" && e.metaKey) {
     commandPaletteEl.show();
@@ -92,7 +78,7 @@ inputEl.addEventListener("keydown", (e) => {
 
   const items = [...listEl.querySelectorAll("sl-menu-item")];
   if (e.key === "ArrowUp") items.reverse();
-  
+
   for (const menuItem of items) {
     if (menuItem.classList.contains("hide")) continue;
     // @ts-ignore
@@ -110,7 +96,8 @@ listEl.addEventListener(
     if (action === "set-title") {
       showForm(setTitleFormEl, "Set Title");
     } else if (action === "save") {
-      showForm(saveFormEl, "Save To Disk");
+      downloadResource("/_/logs");
+      commandPaletteEl.hide();
     } else if (action === "help") {
       showForm(helpFormEl, "Help Menu");
     }

--- a/public/index.html
+++ b/public/index.html
@@ -63,12 +63,26 @@
       <sl-input class="palette-filter" autofocus placeholder="Search"></sl-input>
       <sl-menu>
         <sl-menu-item value="set-title">Set Title</sl-menu-item>
+        <sl-menu-item value="save">Save Logs To Disk</sl-menu-item>
         <sl-menu-item value="help">Help</sl-menu-item>
       </sl-menu>
     </form>
 
     <form class="hide title-form">
-      <sl-input autofocus placeholder="New page title"></sl-input>
+      <sl-input label="New Title" autofocus placeholder="New page title"></sl-input>
+      <div class="form-footer">
+        <sl-button type="submit">Change Title</sl-button>
+      </div>
+    </form>
+    <form class="hide save-to-disk">
+
+      <sl-input label="Folder location" name="folder"
+        value="~/.logpipe/" autofocus placeholder="Location..."></sl-input>
+      <sl-input label="File Name" name="file"
+        value="file.log" autofocus placeholder="Name..."></sl-input>
+      <div class="form-footer">
+        <sl-button type="submit">Save File</sl-button>
+      </div>
     </form>
     <form class="hide help-menu">
       <dl>
@@ -82,7 +96,8 @@
 
         <dt>How do I specify a port?</dt>
         <dd>
-          <p>The command line supports the options <code>--port</code> and <code>--title</code> for specifying these things.</p>
+          <p>The command line supports the options <code>--port</code> and <code>--title</code> for specifying these
+            things.</p>
           <p>
             <code>my-program | logpipe --port 8080 --title "Backend System"</code>
           </p>

--- a/public/index.html
+++ b/public/index.html
@@ -74,15 +74,6 @@
         <sl-button type="submit">Change Title</sl-button>
       </div>
     </form>
-    <form class="hide save-to-disk">
-      <sl-input label="Folder location" name="folder"
-        value="~/.logpipe/" autofocus placeholder="Location..."></sl-input>
-      <sl-input label="File Name" name="file"
-        value="file.log" autofocus placeholder="Name..."></sl-input>
-      <div class="form-footer">
-        <sl-button type="submit">Save File</sl-button>
-      </div>
-    </form>
     <form class="hide help-menu">
       <dl>
         <dt>My logs aren't showing!</dt>

--- a/public/index.html
+++ b/public/index.html
@@ -75,7 +75,6 @@
       </div>
     </form>
     <form class="hide save-to-disk">
-
       <sl-input label="Folder location" name="folder"
         value="~/.logpipe/" autofocus placeholder="Location..."></sl-input>
       <sl-input label="File Name" name="file"

--- a/public/index.js
+++ b/public/index.js
@@ -70,7 +70,7 @@ async function appendLog(...logEls) {
   }
 }
 
-const cliSource = new EventSource("/cli-input");
+const cliSource = new EventSource("/_/cli-input");
 /** @param {Event & { data: string }} event */
 cliSource.onmessage = async (event) => {
   const data = JSON.parse(event.data);

--- a/public/lib.js
+++ b/public/lib.js
@@ -64,3 +64,16 @@ export function isInView(logEl, root) {
     }, 5);
   });
 }
+
+/**
+ * Download resource via an <a> tag
+ * @param {string} url raw URL or data URL
+ */
+export function downloadResource(url) {
+  const a = document.createElement('a');
+  a.href = url;
+  a.setAttribute('download', 'true');
+  document.body.append(a);
+  a.click();
+  a.remove();
+}

--- a/public/lib.js
+++ b/public/lib.js
@@ -68,11 +68,12 @@ export function isInView(logEl, root) {
 /**
  * Download resource via an <a> tag
  * @param {string} url raw URL or data URL
+ * @param {string} name name for file ("file" by default)
  */
-export function downloadResource(url) {
+export function downloadResource(url, name = 'file') {
   const a = document.createElement('a');
   a.href = url;
-  a.setAttribute('download', 'true');
+  a.setAttribute('download', name);
   document.body.append(a);
   a.click();
   a.remove();

--- a/public/style.css
+++ b/public/style.css
@@ -241,6 +241,11 @@ header {
   }
 }
 
+sl-dialog form:not(.palette-form, .hide) {
+  display: grid;
+  gap: var(--sl-spacing-medium);
+}
+
 form.help-menu {
   dl {
     padding: 0 var(--sl-spacing-x-large);
@@ -259,10 +264,10 @@ form.help-menu {
   code.multiline {
     display: block;
   }
-  .form-footer {
-    display: flex;
-    justify-content: flex-end;
-  }
+}
+.form-footer {
+  display: flex;
+  justify-content: flex-end;
 }
 
 kbd {


### PR DESCRIPTION
Closes https://github.com/EmNudge/logpipe/issues/31

The original idea was to write directly to FS using node, but this requires specifying a download location. If we choose one for the user, it may be hard to find (or cause conflicts). If we take input from the user, we're giving the user a chance to shoot themselves in the foot.

Instead we now just emit the logs through an endpoint. By using an `a` tag, we can download it as a JSON file.